### PR TITLE
make the directive null- and undefined-safe.

### DIFF
--- a/markdown.js
+++ b/markdown.js
@@ -14,7 +14,7 @@ angular.module('btford.markdown', []).
       link: function (scope, element, attrs) {
         if (attrs.btfMarkdown) {
           scope.$watch(attrs.btfMarkdown, function (newVal) {
-            var html = converter.makeHtml(newVal);
+            var html = newVal ? converter.makeHtml(newVal) : '';
             element.html(html);
           });
         } else {


### PR DESCRIPTION
Passing null or undefined to converter.makeHtml() throws an exception.
