### PR TITLE
minification safety

### DIFF
--- a/markdown.js
+++ b/markdown.js
@@ -18,7 +18,7 @@ angular.module('btford.markdown', ['ngSanitize']).
       }
     };
   }).
-  directive('btfMarkdown', function ($sanitize, markdownConverter) {
+  directive('btfMarkdown', ['$sanitize', 'markdownConverter', function ($sanitize, markdownConverter) {
     return {
       restrict: 'AE',
       link: function (scope, element, attrs) {
@@ -33,4 +33,4 @@ angular.module('btford.markdown', ['ngSanitize']).
         }
       }
     };
-  });
+  }]);


### PR DESCRIPTION
Unless use /w automatic minification safety preprocessors, the extension breaks. This tiny change fixes things.
