### PR TITLE
fix: make minifier-safe via long-form injector syntax.

### DIFF
--- a/markdown.js
+++ b/markdown.js
@@ -18,7 +18,7 @@ angular.module('btford.markdown', ['ngSanitize']).
       }
     };
   }).
-  directive('btfMarkdown', function ($sanitize, markdownConverter) {
+  directive('btfMarkdown', ['$sanitize', 'markdownConverter', function ($sanitize, markdownConverter) {
     return {
       restrict: 'AE',
       link: function (scope, element, attrs) {
@@ -33,4 +33,4 @@ angular.module('btford.markdown', ['ngSanitize']).
         }
       }
     };
-  });
+  }]);


### PR DESCRIPTION
Minifiers commonly rename function param names, which subsequently breaks injection. Using the long form fixes this.
