### PR TITLE
adds $compile to the "btfMarkdown" directive

### DIFF
--- a/markdown.js
+++ b/markdown.js
@@ -18,7 +18,7 @@ angular.module('btford.markdown', ['ngSanitize']).
       }
     };
   }).
-  directive('btfMarkdown', ['$sanitize', 'markdownConverter', function ($sanitize, markdownConverter) {
+  directive('btfMarkdown', ['$sanitize', 'markdownConverter', '$compile', function ($sanitize, markdownConverter, $compile) {
     return {
       restrict: 'AE',
       link: function (scope, element, attrs) {
@@ -26,10 +26,12 @@ angular.module('btford.markdown', ['ngSanitize']).
           scope.$watch(attrs.btfMarkdown, function (newVal) {
             var html = newVal ? $sanitize(markdownConverter.makeHtml(newVal)) : '';
             element.html(html);
+            $compile(element.contents())(scope);
           });
         } else {
           var html = $sanitize(markdownConverter.makeHtml(element.text()));
           element.html(html);
+          $compile(element.contents())(scope);
         }
       }
     };


### PR DESCRIPTION
Adding $compile allows developers to create showdown extensions that convert md text to angular directives, and to add angular models in your md file.

Ex:  "you have {{ctrl.points}} points" become "you have 3 points"