### PR TITLE
Fix example in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,7 @@ Bower Component for a simple AngularJS Markdown directive using [Showdown](https
 6. Insert the `btf-markdown` directive into your template:
 
 ```html
-<btf-markdown>
-  #Markdown directive
-  *It works!*
-</btf-markdown>
+<btf-markdown>#Markdown directive *It works!*</btf-markdown>
 ```
 
 You can also bind the markdown input to a scope variable:


### PR DESCRIPTION
Fix for Issue #53 

Example, as given renders in  <pre><code>...</pre></code> tags because the lines within the <btf-markdown> element are prefixed with four spaces. By move the example to a single line, the markdown is rendered as <h1>...<em></em>...</h1> as intended.