### PR TITLE
Optional compileHtml attribute

### DIFF
--- a/markdown.js
+++ b/markdown.js
@@ -4,33 +4,38 @@
  * License: MIT
  */
 
-'use strict';
+"use strict";
 
-angular.module('btford.markdown', ['ngSanitize']).
-  provider('markdownConverter', function () {
-    var opts = {};
-    return {
-      config: function (newOpts) {
-        opts = newOpts;
-      },
-      $get: function () {
-        return new Showdown.converter(opts);
-      }
-    };
-  }).
-  directive('btfMarkdown', ["$sanitize", "$compile", "markdownConverter", function ($sanitize, $compile, markdownConverter) {
-    return {
-      restrict: 'AE',
-      link: function (scope, element, attrs) {
-        if (attrs.btfMarkdown) {
-          scope.$watch(attrs.btfMarkdown, function (newVal) {
-            var html = newVal ? $sanitize(markdownConverter.makeHtml(newVal)) : '';
-            element.html($compile(html)(scope));
-          });
-        } else {
-          var html = $sanitize(markdownConverter.makeHtml(element.text()));
-          element.html($compile(html)(scope));
+angular.module("btford.markdown", ["ngSanitize"])
+    .provider("markdownConverter",
+    function () {
+        var opts = {};
+        return {
+            config: function (newOpts) { opts = newOpts; },
+            $get: function () { return new showdown.Converter(opts); }
+        };
+    })
+    .directive("btfMarkdown",
+    [
+        "$sanitize", "$compile", "markdownConverter", function ($sanitize, $compile, markdownConverter) {
+            return {
+                restrict: "AE",
+                link: function (scope, element, attrs) {
+
+                    console.log("btfMarkdown", attrs);
+
+                    if (attrs.btfMarkdown) {
+                        scope.$watch(attrs.btfMarkdown, function (newVal) {
+                            element.html(newVal ? $sanitize(markdownConverter.makeHtml(newVal)) : "");
+
+                            if (attrs.compileHtml) $compile(element.contents())(scope);
+                        });
+                    } else {
+                        element.html($sanitize(markdownConverter.makeHtml(element.text())));
+                        if (attrs.compileHtml) $compile(element.contents())(scope);
+
+                    }
+                }
+            };
         }
-      }
-    };
-  }]);
+    ]);

--- a/markdown.js
+++ b/markdown.js
@@ -21,9 +21,6 @@ angular.module("btford.markdown", ["ngSanitize"])
             return {
                 restrict: "AE",
                 link: function (scope, element, attrs) {
-
-                    console.log("btfMarkdown", attrs);
-
                     if (attrs.btfMarkdown) {
                         scope.$watch(attrs.btfMarkdown, function (newVal) {
                             element.html(newVal ? $sanitize(markdownConverter.makeHtml(newVal)) : "");
@@ -32,8 +29,8 @@ angular.module("btford.markdown", ["ngSanitize"])
                         });
                     } else {
                         element.html($sanitize(markdownConverter.makeHtml(element.text())));
+                        
                         if (attrs.compileHtml) $compile(element.contents())(scope);
-
                     }
                 }
             };

--- a/markdown.js
+++ b/markdown.js
@@ -18,18 +18,18 @@ angular.module('btford.markdown', ['ngSanitize']).
       }
     };
   }).
-  directive('btfMarkdown', ['$sanitize', 'markdownConverter', function ($sanitize, markdownConverter) {
+  directive('btfMarkdown', ["$sanitize", "$compile", "markdownConverter", function ($sanitize, $compile, markdownConverter) {
     return {
       restrict: 'AE',
       link: function (scope, element, attrs) {
         if (attrs.btfMarkdown) {
           scope.$watch(attrs.btfMarkdown, function (newVal) {
             var html = newVal ? $sanitize(markdownConverter.makeHtml(newVal)) : '';
-            element.html(html);
+            element.html($compile(html)(scope));
           });
         } else {
           var html = $sanitize(markdownConverter.makeHtml(element.text()));
-          element.html(html);
+          element.html($compile(html)(scope));
         }
       }
     };


### PR DESCRIPTION
This pull adds an optional `compile-html='true'` attribute to the directive, allowing the HTML output to be used as a template.